### PR TITLE
Wildcard matching should pass on the matched subdomain name

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function vhost(hostname, server){
     var host = req.headers.host.split(':')[0];
     var matches = regexp.exec(host);
     if (matches == null) return next();
-    req.vhost = matches.slice(1);
+    req.vhost = matches.slice(1).reverse();
     if ('function' == typeof server) return server(req, res, next);
     server.emit('request', req, res);
   };

--- a/test/test.js
+++ b/test/test.js
@@ -117,7 +117,7 @@ describe('vhost()', function(){
       .expect('loki', done);
     })
 
-    it('should return multiple matches in req.vhost', function(done){
+    it('should return multiple matches in req.vhost, in right-to-left order', function(done){
       var app  = connect()
         , loki = http.createServer(function(req, res){
           res.end( req.vhost[0] + ',' + req.vhost[1] ) 
@@ -128,7 +128,7 @@ describe('vhost()', function(){
       request(app.listen())
       .get('/')
       .set('Host', 'user-loki.group-tobi.ferrets.com')
-      .expect('loki,tobi', done);
+      .expect('tobi,loki', done);
     })
 
   })


### PR DESCRIPTION
1) For wildcard matching, I refactored and added a couple more tests to ensure that matching is done in the order the vhosts are added. Nothing unexpected here. Just some clarification.

2) When using wildcard to match subdomains, I'd like to know the subdomain name that was matched. For example, I may have one server serving www.example.com while another one serving other subdomains like john.example.com, larry.example.com, and moe.example.com. In the second case I want to know whether I'm serving john, larry, or moe. I decide to return that as a string in req.vhost.
    In principle one can use multiple wildcards, so there can be multiple matched parts. I imagine that's a really rare use-case though, so I focused on returning just the first match and make it user-friendly for that case. I'm open to discussion though.
