### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function isregexp(val){
 
 function hostregexp(val){
   var source = !isregexp(val)
-    ? String(val).replace(/([.+?^=!:${}()|\[\]\/\\])/g, '\\$1').replace(/\*/g, '([^\.]+)')
+    ? String(val).replace(/([.+?^=!:${}()|\[\]\/\\])/g, '\\$1').replace(/[*]/g, '(?:.*?)')
     : val.source
 
   // force leading anchor matching


### PR DESCRIPTION
The new regex breaks with the old express.vhost and doesn't work for wildcard subdomains (*.mydomain.com). This reverts it to express.vhost regex. Here's a test for `curl dev.mydomain.com:3000`

```
var connect = require('connect');
var vhost = require('vhost');

var vapp = connect();

vapp.use('/', function (req, res) {
  res.end('Hello from Connect!\n');
});
var app = connect();

app.use(vhost('*m.mydomain.com', vapp)); // doesnt work, 404

// app.use(vhost('dev.m.mydomain.com', vapp)); // works

app.listen(3000);
```
