### PR TITLE
Add ability to pass an array of hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ characters in that section of the hostname.
 * When `hostname` is a RegExp, it will be forced to case-insensitive (since
 hostnames are) and will be forced to match based on the start and end of the
 hostname.
-* When `hostname` is an array, each item can either be an array or RegExp as
-described above.  A domain match will be when one item matches.
+* When `hostname` is an array, each item can be either an array or RegExp (as
+described above).  A domain match will be when one item array matches.
 
 When host is matched and the request is sent down to a vhost handler, the `req.vhost`
 property will be populated with an object. This object will have numeric properties

--- a/README.md
+++ b/README.md
@@ -24,10 +24,15 @@ Create a new middleware function to hand off request to `handle` when the incomi
 host for the request matches `hostname`. The function is called as
 `handle(req, res, next)`, like a standard middleware.
 
-`hostname` can be a string or a RegExp object. When `hostname` is a string it can
-contain `*` to match 1 or more characters in that section of the hostname. When
-`hostname` is a RegExp, it will be forced to case-insensitive (since hostnames are)
-and will be forced to match based on the start and end of the hostname.
+`hostname` can be a string, a RegExp object or any array containing either of
+these.
+* When `hostname` is a string it can contain `*` to match 1 or more
+characters in that section of the hostname.
+* When `hostname` is a RegExp, it will be forced to case-insensitive (since
+hostnames are) and will be forced to match based on the start and end of the
+hostname.
+* When `hostname` is an array, each item can either be an array or RegExp as
+described above.  A domain match will be when one item matches.
 
 When host is matched and the request is sent down to a vhost handler, the `req.vhost`
 property will be populated with an object. This object will have numeric properties

--- a/index.js
+++ b/index.js
@@ -103,26 +103,56 @@ function isregexp(val) {
 }
 
 /**
- * Generate RegExp for given hostname value.
+ * Determine if object is an array.
+ *
+ * @param (object} val
+ * @return {boolean}
+ * @private
+ */
+
+function isarray(val) {
+  return (Object.prototype.toString.call(val) === '[object Array]' );
+}
+
+
+/**
+ * Generate RegExp group for the supplied value.
+ *
+ * @param (string|RegExp} val
+ * @private
+ */
+
+function hostregexpgroup(val) {
+  var source = !isregexp(val)
+      ? String(val).replace(escapeRegExp, escapeReplace).replace(asteriskRegExp, asteriskReplace)
+      : val.source
+
+  // force leading anchor matching
+  if (source[0] === '^') {
+    source = source.slice(0, 1);
+  }
+
+  // force trailing anchor matching
+  if (endAnchoredRegExp.test(source)) {
+    source = source.slice(0, -1);
+  }
+
+  return '(?:' + source + ')';
+}
+
+/**
+ * Generate RegExp for given hostname(s) value.
  *
  * @param (string|RegExp} val
  * @private
  */
 
 function hostregexp(val) {
-  var source = !isregexp(val)
-    ? String(val).replace(escapeRegExp, escapeReplace).replace(asteriskRegExp, asteriskReplace)
-    : val.source
+  val = ((isarray(val))?val:[val]);
 
-  // force leading anchor matching
-  if (source[0] !== '^') {
-    source = '^' + source
-  }
-
-  // force trailing anchor matching
-  if (!endAnchoredRegExp.test(source)) {
-    source += '$'
-  }
+  var source = '^' + val.map(function(val) {
+    return hostregexpgroup(val);
+  }).join('|') + '$';
 
   return new RegExp(source, 'i')
 }

--- a/test/test.js
+++ b/test/test.js
@@ -209,7 +209,58 @@ describe('vhost(hostname, server)', function(){
       .expect(200, '[["0","bob"],["1","foo"],["host","user-bob.foo.com:8080"],["hostname","user-bob.foo.com"],["length",2]]', done)
     })
   })
+
+  describe('with array hostname', function(){
+    it('should match using an array of strings', function(done){
+      var domains = ['toki.com', 'www.toki.com', 'toki.org']
+
+      function next() {
+        if(domains.length) {
+          request(app)
+              .get('/')
+              .set('Host', domains.pop())
+              .expect(200, 'toki', done)
+        } else {
+          done()
+        }
+
+      }
+
+      var app = createServerArray(domains, function(req, res){
+        res.end('toki')
+      })
+
+      next()
+    })
+
+    it('should match using an array of RegEx\'s and strings', function(done){
+      var domains = ['toki.com', 'www.toki.com', 'toki.org', 'www.toki.org', 'tobi.com', 'tabbi.com']
+      var tests = [/(?:www|)\.toki\.(?:com|org)/, 'tobi.com', 'tabbi.com']
+
+      function next() {
+        if(domains.length) {
+          request(app)
+              .get('/')
+              .set('Host', domains.pop())
+              .expect(200, 'toki', done)
+        } else {
+          done()
+        }
+
+      }
+
+      var app = createServerArray(tests, function(req, res){
+        res.end('toki')
+      })
+
+      next()
+    })
+  })
 })
+
+function createServerArray(hostname, server) {
+  return createServer([vhost(hostname, server)])
+}
 
 function createServer(hostname, server) {
   var vhosts = !Array.isArray(hostname)


### PR DESCRIPTION
I needed the ability to pass an array of hostnames to vhost, so tweaked the code a little to do this.

Admittedly, this could be achieved with a carefully constructed RegEx.  However, in some circumstances it is cleaner to pass array.  If the configs for each vhost are in a json file, it's nice to use an array.  Much easier to read than a RegEx.

**Eg:**

```javascript
vhost([
    'loaclhost.example.org',
    'example.org',
    'www.example.org'
], app);
```