### PR TITLE
fix: fixed stack overflow issue on 1200+ vhosts

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,8 +54,8 @@ function vhost (hostname, handle) {
     var vhostdata = vhostof(req, regexp)
 
     if (!vhostdata) {
-      return process.nextTick(function() {
-        return next();
+      return process.nextTick(function () {
+        return next()
       })
     }
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,9 @@ function vhost (hostname, handle) {
     var vhostdata = vhostof(req, regexp)
 
     if (!vhostdata) {
-      return next()
+      return process.nextTick(function() {
+        return next();
+      })
     }
 
     // populate


### PR DESCRIPTION
We had some issues while adopting `vhost` on a large codebase including a large set of vhosts. It looks like the express.js' `next()` callback is saturating the stack as it acts *like* a recursive function. By wrapping the `next()` callback call into a `process.nextTick`, we're able to free the call stack before pushing a new function call to it.

We tested this PR against up to ~50000 vhosts and it definitely solved the issue.

Feel free to ask if you have any questions!