### PR TITLE
CI workflow refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,22 @@ on:
 - push
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 'lts/*'
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts --include=dev
+
+      - name: Run lint
+        run: node --run lint # Use `node --run` to run the script in package.json
+
   test:
     runs-on: ubuntu-20.04
     strategy:
@@ -170,10 +186,6 @@ jobs:
         else
           npm test
         fi
-
-    - name: Lint code
-      if: steps.list_env.outputs.eslint != ''
-      run: npm run lint
 
     - name: Collect code coverage
       if: steps.list_env.outputs.nyc != ''


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 
-->

[Call for Contribution](https://github.com/expressjs/vhost/pull/51#issuecomment-2888494904), [Coveralls Page](https://coveralls.io/github/expressjs/vhost)

This PR is created for making the CI pipeline stable again for future developments. The changes are very similar to express's CI pipeline to make sure `expressjs` organization follows the same or similar CI conditions.

Inspired by https://github.com/expressjs/express/pull/5599

### Changes

- [x] Add specific `lint` job for the CI
> Used `node --run lint` instead of `npm run lint` where it's possible. 

#### Questions
- [ ] Is using `latest` version of ubuntu is a good practice? What about using `ubuntu-24.04`?
- [ ] Should we remove deprecated node (and io.js) versions from the test matrix?
- [ ] Shall we add macos and windows to test os matrix?

---

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
